### PR TITLE
New detours; logging improvements; etc.

### DIFF
--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -259,7 +259,7 @@ BOOL WINAPI DetourReadFile(
 	return ret;
 }
 
-void ReadFileExCallback(
+void CALLBACK ReadFileExCallback(
 	DWORD dwErrorCode,
 	DWORD dwNumberOfBytesTransfered,
 	LPOVERLAPPED lpOverlapped

--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -651,7 +651,7 @@ BOOL WINAPI DllMain(HINSTANCE dll_handle, DWORD reason, LPVOID reserved)
 					method == (FILE_READ_ACCESS | FILE_WRITE_ACCESS) ? "FILE_READ_ACCESS | FILE_WRITE_ACCESS" :
 					"INVALID_ACCESS";
 
-				_logger->info("- Code: {:#8x}  Macro: CTL_CODE({:#4x}, {:#3x}, {}, {})",
+				_logger->info("- Code: 0x{:08X}  Macro: CTL_CODE(0x{:04X}, 0x{:03X}, {}, {})",
 					code,
 					deviceType,
 					function,

--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -100,9 +100,6 @@ HANDLE WINAPI DetourCreateFileA(
 
 	const bool isOfInterest = (path.rfind("\\\\", 0) == 0);
 
-	if (isOfInterest)
-		_logger->info("lpFileName = {}", path);
-
 	const auto handle = real_CreateFileA(
 		lpFileName,
 		dwDesiredAccess,
@@ -113,11 +110,10 @@ HANDLE WINAPI DetourCreateFileA(
 		hTemplateFile
 	);
 
-	if (handle != INVALID_HANDLE_VALUE)
+	if (isOfInterest && handle != INVALID_HANDLE_VALUE)
 	{
 		g_handleToPath[handle] = path;
-		if (isOfInterest)
-			_logger->info("handle = {}, lpFileName = {}", handle, path);
+		_logger->info("handle = {}, lpFileName = {}", handle, path);
 	}
 
 	return handle;
@@ -141,9 +137,6 @@ HANDLE WINAPI DetourCreateFileW(
 
 	const bool isOfInterest = (path.rfind("\\\\", 0) == 0);
 
-	if (isOfInterest)
-		_logger->info("lpFileName = {}", path);
-
 	const auto handle = real_CreateFileW(
 		lpFileName,
 		dwDesiredAccess,
@@ -154,11 +147,10 @@ HANDLE WINAPI DetourCreateFileW(
 		hTemplateFile
 	);
 
-	if (handle != INVALID_HANDLE_VALUE)
+	if (isOfInterest && handle != INVALID_HANDLE_VALUE)
 	{
 		g_handleToPath[handle] = path;
-		if (isOfInterest)
-			_logger->info("handle = {}, lpFileName = {}", handle, path);
+		_logger->info("handle = {}, lpFileName = {}", handle, path);
 	}
 
 	return handle;

--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -212,11 +212,12 @@ BOOL WINAPI DetourReadFile(
 	const auto bufSize = std::min(nNumberOfBytesToRead, tmpBytesRead);
 	const std::vector<char> outBuffer(charInBuf, charInBuf + bufSize);
 
-	_logger->info("success = {}, lastError = 0x{:08X}, path = {} ({:04d}) -> {:Xpn}",
+	_logger->info("success = {}, lastError = 0x{:08X}, path = {} bytesToRead: {:04d}, bytesRead: {:04d} -> {:Xpn}",
 		ret ? "true" : "false",
 		ret ? ERROR_SUCCESS : error,
 		path,
-		bufSize,
+		nNumberOfBytesToRead,
+		tmpBytesRead,
 		spdlog::to_hex(outBuffer)
 	);
 
@@ -258,17 +259,17 @@ BOOL WINAPI DetourWriteFile(
 	}
 #endif
 
-	const auto bufSize = std::min(nNumberOfBytesToWrite, tmpBytesWritten);
-	const std::vector<char> inBuffer(charInBuf, charInBuf + bufSize);
+	const std::vector<char> inBuffer(charInBuf, charInBuf + nNumberOfBytesToWrite);
 	
 	// Prevent the logger from causing a crash via exception when it double-detours WriteFile
 	try
 	{
-		_logger->info("success = {}, lastError = 0x{:08X}, path = {} ({:04d}) -> {:Xpn}",
+		_logger->info("success = {}, lastError = 0x{:08X}, path = {}, bytesToWrite: {:04d}, bytesWritten: {:04d} -> {:Xpn}",
 			ret ? "true" : "false",
 			ret ? ERROR_SUCCESS : error,
 			path,
-			bufSize,
+			nNumberOfBytesToWrite,
+			tmpBytesWritten,
 			spdlog::to_hex(inBuffer)
 		);
 	}

--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -112,10 +112,17 @@ HANDLE WINAPI DetourCreateFileA(
 		hTemplateFile
 	);
 
-	if (isOfInterest && handle != INVALID_HANDLE_VALUE)
+	if (isOfInterest)
 	{
-		g_handleToPath[handle] = path;
-		_logger->info("handle = {}, lpFileName = {}", handle, path);
+		if (handle != INVALID_HANDLE_VALUE)
+		{
+			g_handleToPath[handle] = path;
+			_logger->info("handle = {}, lpFileName = {}", handle, path);
+		}
+		else
+		{
+			_logger->info("lpFileName = {}, lastError = {}", path, GetLastError());
+		}
 	}
 
 	return handle;
@@ -149,10 +156,17 @@ HANDLE WINAPI DetourCreateFileW(
 		hTemplateFile
 	);
 
-	if (isOfInterest && handle != INVALID_HANDLE_VALUE)
+	if (isOfInterest)
 	{
-		g_handleToPath[handle] = path;
-		_logger->info("handle = {}, lpFileName = {}", handle, path);
+		if (handle != INVALID_HANDLE_VALUE)
+		{
+			g_handleToPath[handle] = path;
+			_logger->info("handle = {}, lpFileName = {}", handle, path);
+		}
+		else
+		{
+			_logger->info("lpFileName = {}, lastError = {}", path, GetLastError());
+		}
 	}
 
 	return handle;

--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -501,19 +501,19 @@ BOOL WINAPI DetourDeviceIoControl(
 		              spdlog::to_hex(inBuffer)
 		);
 	}
-#ifdef XINPUTHOOKER_LOG_UNKNOWN_IOCTLS
 	else
 	{
 		// Add control code to list of unknown codes
 		g_newIoctls[dwIoControlCode] = true;
+#ifdef XINPUTHOOKER_LOG_UNKNOWN_IOCTLS
 		_logger->info("[I] [0x{:08X}] path = {} ({:04d}) -> {:Xpn}",
 		              dwIoControlCode,
 		              path,
 		              nInBufferSize,
 		              spdlog::to_hex(inBuffer)
 		);
-	}
 #endif
+	}
 
 	if (lpOutBuffer && nOutBufferSize > 0)
 	{
@@ -624,7 +624,6 @@ BOOL WINAPI DllMain(HINSTANCE dll_handle, DWORD reason, LPVOID reserved)
 		DetourDetach((PVOID*)&real_GetOverlappedResult, DetourGetOverlappedResult);
 		DetourTransactionCommit();
 
-#ifdef XINPUTHOOKER_LOG_UNKNOWN_IOCTLS
 		if (g_newIoctls.size() > 0)
 		{
 			std::shared_ptr<spdlog::logger> _logger = spdlog::get("XInputHooker")->clone("NewIoctls");
@@ -660,7 +659,6 @@ BOOL WINAPI DllMain(HINSTANCE dll_handle, DWORD reason, LPVOID reserved)
 				);
 			}
 		}
-#endif
 		break;
 	}
 	return TRUE;

--- a/XInputHooker/XInputHooker.cpp
+++ b/XInputHooker/XInputHooker.cpp
@@ -70,14 +70,15 @@ BOOL WINAPI DetourSetupDiEnumDeviceInterfaces(
 	auto retval = real_SetupDiEnumDeviceInterfaces(DeviceInfoSet, DeviceInfoData, InterfaceClassGuid, MemberIndex,
 	                                               DeviceInterfaceData);
 
-	_logger->info("InterfaceClassGuid = {{{0:X}-{1:X}-{2:X}-{3:X}{4:X}-{5:X}{6:X}{7:X}{8:X}{9:X}{10:X}}}, "
-	              "return = 0x{11:X}, error = 0x{12:X}",
+	_logger->info("InterfaceClassGuid = {{{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}}}, "
+	              "success = {}, error = 0x{:08X}",
 	              InterfaceClassGuid->Data1, InterfaceClassGuid->Data2, InterfaceClassGuid->Data3,
 	              InterfaceClassGuid->Data4[0], InterfaceClassGuid->Data4[1], InterfaceClassGuid->Data4[2],
 	              InterfaceClassGuid->Data4[3],
 	              InterfaceClassGuid->Data4[4], InterfaceClassGuid->Data4[5], InterfaceClassGuid->Data4[6],
 	              InterfaceClassGuid->Data4[7],
-	              retval, GetLastError());
+	              retval ? "true" : "false",
+				  retval ? ERROR_SUCCESS : GetLastError());
 
 	return retval;
 }
@@ -184,9 +185,9 @@ BOOL WINAPI DetourWriteFile(
 	// Prevent the logger from causing a crash via exception when it double-detours WriteFile
 	try
 	{
-		_logger->info("={}, lastError={} ({:04d}) -> {:Xpn}",
-			ret,
-			error,
+		_logger->info("success = {}, lastError = 0x{:08X} ({:04d}) -> {:Xpn}",
+			ret ? "true" : "false",
+			ret ? ERROR_SUCCESS : error,
 			bufSize,
 			spdlog::to_hex(inBuffer)
 		);
@@ -213,9 +214,9 @@ BOOL WINAPI DetourGetOverlappedResult(
 	if (lpNumberOfBytesTransferred)
 		*lpNumberOfBytesTransferred = tmpBytesTransferred;
 	
-	_logger->info("ret={}, lastError={}, bytesWritten={}",
-		ret,
-		error,
+	_logger->info("success = {}, lastError = 0x{:08X}, bytesTransferred = {}",
+		ret ? "true" : "false",
+		ret ? ERROR_SUCCESS : error,
 		tmpBytesTransferred
 	);
 	


### PR DESCRIPTION
Well, this was fun to work on lol

New detours:
- CloseHandle
- ReadFile
- ReadFileEx

Logging improvements:
- Make use of tracked handles to log handle paths
  - Only keep track of handles of interest
  - Added CloseHandle detour to stop tracking closed handles
- Make all hexadecimal-formatted numbers be padded with 0s to fill the minimum requested size of characters
- Don't log for unknown file handles by default
  - Added a compile option to allow
- Keep track of unknown IOCTL codes, and print them out at the end of the session (both in hexadecimal and `CTL_CODE` macro)
- Add compile option to log unknown IOCTLs as they are occurring
- Don't log paths in CreateFile twice; only log once with different message formats for success and failure
- Log bytes to write/read individually from bytes written/read
- Filter out regular file paths that use the `\\?\` or `\\.\` prefix by checking against the available drive letters on the system
- Other general message format string changes